### PR TITLE
Added cfile used in srlabs airprobe howto

### DIFF
--- a/srlabs_howto/description.txt
+++ b/srlabs_howto/description.txt
@@ -1,0 +1,11 @@
+freq:           1847.8 MHz
+arfcn:          725
+band:           DCS1800
+sample rate:    100e6
+decimation:     174
+Kc:             0x1E,0xF0,0x0B,0xAB,0x3B,0xAC,0x70,0x02
+
+C0 config:      BCCH (Non-combined)
+SDCCH timeslot: 1
+TCH/F timeslot: 5         
+TCH/F codec:    FR


### PR DESCRIPTION
Hi Piotr, 

I added the capture file used in srlab's airprobe howto, as I believe it is widely used as entry point for many users. 

I will also add a small howto for airprobe_decode in the usage section of the wiki, which will refer to that file.
